### PR TITLE
Supported zeitwerk

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This plugin allows users to self-join selected Projects.
 
 ## Requirements
 
- - Redmine >= 3.4.0
+ - Redmine >= 4.0.0
 
 ## Installation
 
@@ -35,6 +35,9 @@ TBD
 The GTT Project appreciates any [contributions](https://github.com/gtt-project/.github/blob/main/CONTRIBUTING.md)! Feel free to contact us for [reporting problems and support](https://github.com/gtt-project/.github/blob/main/CONTRIBUTING.md).
 
 ## Version History
+
+- 2.0.0 Support Redmine 5.0 and drop Redmine <= 3.4 support
+- 1.2.0 Publish on GitHub
 
 See [all releases](https://github.com/gtt-project/redmine_admissions/releases) with release notes.
 

--- a/init.rb
+++ b/init.rb
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
 
-require 'redmine'
+require File.expand_path('../lib/redmine_admissions/view_hooks', __FILE__)
 
-Rails.configuration.to_prepare do
-  RedmineAdmissions.setup
+if Rails.version > '6.0' && Rails.autoloaders.zeitwerk_enabled?
+  Rails.application.config.after_initialize do
+    RedmineAdmissions.setup
+  end
+else
+  Rails.configuration.to_prepare do
+    RedmineAdmissions.setup
+  end
 end
 
 Redmine::Plugin.register :redmine_admissions do
@@ -17,4 +23,3 @@ Redmine::Plugin.register :redmine_admissions do
   requires_redmine version_or_higher: '3.4.0'
 
 end
-

--- a/init.rb
+++ b/init.rb
@@ -19,8 +19,8 @@ Redmine::Plugin.register :redmine_admissions do
   author_url 'https://github.com/georepublic'
   url 'https://github.com/gtt-project/redmine_admissions'
   description 'Allows users to self-join selected Projects'
-  version '1.2.0'
+  version '2.0.0'
 
-  requires_redmine version_or_higher: '3.4.0'
+  requires_redmine version_or_higher: '4.0.0'
 
 end

--- a/init.rb
+++ b/init.rb
@@ -7,6 +7,7 @@ if Rails.version > '6.0' && Rails.autoloaders.zeitwerk_enabled?
     RedmineAdmissions.setup
   end
 else
+  require 'redmine_admissions'
   Rails.configuration.to_prepare do
     RedmineAdmissions.setup
   end

--- a/lib/redmine_admissions.rb
+++ b/lib/redmine_admissions.rb
@@ -36,5 +36,3 @@ module RedmineAdmissions
     can_leave?(project, user: user)
   end
 end
-
-require 'redmine_admissions/view_hooks'


### PR DESCRIPTION
Supports #3.

Changes proposed in this pull request:
- Support both Redmine 5.0 (zeitwerk) and Redmine 4.x

@gtt-project/maintainer
