### PR TITLE
Adjusted DropAdmissionAssignedRoleId migration to fix uninstall plugin issue

### DIFF
--- a/db/migrate/20180912100500_drop_admission_assigned_role_id.rb
+++ b/db/migrate/20180912100500_drop_admission_assigned_role_id.rb
@@ -1,5 +1,8 @@
 class DropAdmissionAssignedRoleId < ActiveRecord::Migration[5.2]
   def change
-    remove_reference :projects, :admission_assigned_role
+    remove_foreign_key :projects, :roles,
+      column: :admission_assigned_role_id,
+      on_delete: :nullify
+    remove_column :projects, :admission_assigned_role_id, :integer
   end
 end


### PR DESCRIPTION
Fixes #5.

Changes proposed in this pull request:
- Adjusted DropAdmissionAssignedRoleId migration to fix uninstall plugin issue

The uninstall plugin (rollback) issue's cause was that the following migrations were incompatible.
- [db/migrate/20170915125235_add_admission_assigned_role_to_projects.rb](https://github.com/gtt-project/redmine_admissions/blob/559d05fc84530e6e77e6d8714c9fab28d0928154/db/migrate/20170915125235_add_admission_assigned_role_to_projects.rb)
  ```rb
  class AddAdmissionAssignedRoleToProjects < ActiveRecord::Migration[5.2]
    def change
      add_column :projects, :admission_assigned_role_id, :integer
      add_foreign_key :projects, :roles,
        column: :admission_assigned_role_id,
        on_delete: :nullify
    end
  end
  ```
- [db/migrate/20180912100500_drop_admission_assigned_role_id.rb](https://github.com/gtt-project/redmine_admissions/blob/559d05fc84530e6e77e6d8714c9fab28d0928154/db/migrate/20180912100500_drop_admission_assigned_role_id.rb)
  ```rb
  class DropAdmissionAssignedRoleId < ActiveRecord::Migration[5.2]
    def change
      remove_reference :projects, :admission_assigned_role
    end
  end
  ```

This PR adjusted above 2nd one to be compatible with 1st one.

I confirmed that all tests passed and uninstall plugin (rollback) was succeeded.
```bash
$ bundle exec rake db:drop
$ bundle exec rake db:create
$ bundle exec rake db:migrate
$ bundle exec rake redmine:plugins:migrate
$ bundle exec rake redmine:plugins:test RAILS_ENV=test NAME=redmine_admissions
Run options: --seed 55785

# Running:

...

Finished in 1.703080s, 1.7615 runs/s, 25.2484 assertions/s.
3 runs, 43 assertions, 0 failures, 0 errors, 0 skips
$ bundle exec rake redmine:plugins:migrate VERSION=0 NAME=redmine_admissions
```

Here is the SQL command of the part from `log/development.log`, when migrating the plugin.
**Before fix**
```
Migrating to DropAdmissionAssignedRoleId (20180912100500)
  TRANSACTION (0.1ms)  BEGIN
  ↳ plugins/redmine_admissions/db/migrate/20180912100500_drop_admission_assigned_role_id.rb:3:in `change'
   (0.6ms)  ALTER TABLE "projects" DROP COLUMN "admission_assigned_role_id"
  ↳ plugins/redmine_admissions/db/migrate/20180912100500_drop_admission_assigned_role_id.rb:3:in `change'
  ActiveRecord::SchemaMigration Create (0.2ms)  INSERT INTO "schema_migrations" ("version") VALUES ($1) RETURNING "version"  [["version", "20180912100500-redmine_admissions"]]
  ↳ lib/redmine/plugin.rb:525:in `record_version_state_after_migrating'
  TRANSACTION (0.4ms)  COMMIT
  ↳ lib/redmine/plugin.rb:468:in `up'
```
**After fix**
```
Migrating to DropAdmissionAssignedRoleId (20180912100500)
  TRANSACTION (0.2ms)  BEGIN
  ↳ plugins/redmine_admissions/db/migrate/20180912100500_drop_admission_assigned_role_id.rb:3:in `change'
   (0.8ms)  ALTER TABLE "projects" DROP CONSTRAINT "fk_rails_e212b511c3"
  ↳ plugins/redmine_admissions/db/migrate/20180912100500_drop_admission_assigned_role_id.rb:3:in `change'
   (0.4ms)  ALTER TABLE "projects" DROP COLUMN "admission_assigned_role_id"
  ↳ plugins/redmine_admissions/db/migrate/20180912100500_drop_admission_assigned_role_id.rb:6:in `change'
  ActiveRecord::SchemaMigration Create (0.3ms)  INSERT INTO "schema_migrations" ("version") VALUES ($1) RETURNING "version"  [["version", "20180912100500-redmine_admissions"]]
  ↳ lib/redmine/plugin.rb:525:in `record_version_state_after_migrating'
  TRANSACTION (0.5ms)  COMMIT
  ↳ lib/redmine/plugin.rb:468:in `up'
```

And there is no difference (`ALTER TABLE "projects" DROP COLUMN "admission_assigned_role_id"`) except this fix has more precise removing foreign key by (`ALTER TABLE "projects" DROP CONSTRAINT "fk_rails_e212b511c3"`).

@gtt-project/maintainer
