### PR TITLE
Fixed DropAdmissionAssignedRoleId migration for redmine 4.2 (rails 5.2)

### DIFF
--- a/db/migrate/20180912100500_drop_admission_assigned_role_id.rb
+++ b/db/migrate/20180912100500_drop_admission_assigned_role_id.rb
@@ -1,8 +1,6 @@
 class DropAdmissionAssignedRoleId < ActiveRecord::Migration[5.2]
   def change
-    remove_foreign_key :projects, :roles,
-      column: :admission_assigned_role_id,
-      on_delete: :nullify
+    remove_foreign_key :projects, column: :admission_assigned_role_id
     remove_column :projects, :admission_assigned_role_id, :integer
   end
 end


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Fixed DropAdmissionAssignedRoleId migration for redmine 4.2 (rails 5.2)

Rails 5.2 `remove_foreign_key` definition is bit difference from Rails 6.1.
- Rails 5.2:
  - https://api.rubyonrails.org/v5.2/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-remove_foreign_key
    ```rb
    remove_foreign_key(from_table, options_or_to_table = {})
    ```
- Rails 6.1:
  - https://api.rubyonrails.org/v6.1/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-remove_foreign_key
    ```rb
    remove_foreign_key(from_table, to_table = nil, **options)
    ```

@gtt-project/maintainer
